### PR TITLE
Removes dependency on betterparse in favor of using regex

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,6 @@ group 'org.web3j'
 
 repositories {
     mavenCentral()
-    maven { setUrl("https://dl.bintray.com/hotkeytlt/maven") }
     jcenter()
 }
 
@@ -58,7 +57,6 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
             "org.apache.commons:commons-lang3:3.0",
             "com.github.zafarkhaja:java-semver:0.9.0",
-            'com.github.h0tk3y.betterParse:better-parse-jvm:0.4.0-alpha-3',
             "org.jetbrains.kotlinx:kotlinx-serialization-runtime:0.14.0"
     testImplementation "org.junit.jupiter:junit-jupiter-engine:$junitVersion",
             "org.junit.jupiter:junit-jupiter-api:$junitVersion",

--- a/gradle/spotless/build.gradle
+++ b/gradle/spotless/build.gradle
@@ -23,6 +23,7 @@ spotless {
             include '**/src/*/java/**/*.java'
             exclude '**/.gradle/**'
             exclude '**/generated/**'
+            exclude '**/build/install/**'
         }
         removeUnusedImports()
         googleJavaFormat("1.7").aosp()
@@ -36,6 +37,7 @@ spotless {
         target fileTree('.') {
             include '**/*.kt'
             exclude '**/.gradle/**'
+            exclude '**/build/install/**'
         }
         ktlint('0.31.0')
         trimTrailingWhitespace()

--- a/src/main/kotlin/org/web3j/sokt/VersionResolver.kt
+++ b/src/main/kotlin/org/web3j/sokt/VersionResolver.kt
@@ -58,7 +58,7 @@ class VersionResolver(private val directoryPath: String = ".web3j") {
     }
 
     fun versionsFromString(input: String): List<String> {
-        return Regex("\\s*[\\^<>=\\^~!]{0,4}\\s*(\\d*(\\.?)\\s*){1,3}").findAll(input)
+        return Regex("\\s*[\\^<>=~!]{0,4}\\s*(\\d*(\\.?)\\s*){1,3}").findAll(input)
             .filter { it.groupValues[0].isNotBlank() }.map { it.groupValues[0].trim().replace("\\s".toRegex(), "") }
             .toList()
     }

--- a/src/main/kotlin/org/web3j/sokt/VersionResolver.kt
+++ b/src/main/kotlin/org/web3j/sokt/VersionResolver.kt
@@ -58,7 +58,7 @@ class VersionResolver(private val directoryPath: String = ".web3j") {
     }
 
     fun versionsFromString(input: String): List<String> {
-        return Regex("\\s*[\\^<>=~!]{0,4}\\s*(\\d*(\\.?)\\s*){1,3}").findAll(input)
+        return Regex("\\s*[\\^<>=~!]{0,3}\\s*(\\d*(\\.?)\\s*){1,3}").findAll(input)
             .filter { it.groupValues[0].isNotBlank() }.map { it.groupValues[0].trim().replace("\\s".toRegex(), "") }
             .toList()
     }

--- a/src/test/kotlin/org/web3j/sokt/VersionResolverTest.kt
+++ b/src/test/kotlin/org/web3j/sokt/VersionResolverTest.kt
@@ -110,35 +110,30 @@ class VersionResolverTest {
         """
             0.5.13
             0.5.14
-            0.4.25
+            0.4.26
             0.5.14
             0.5.14
             0.5.14
             0.5.14
-            0.4.25
-            0.4.25
+            0.4.26
+            0.4.26
             null
-            0.4.25
-            null
-            null
-            0.4.25
-            0.5.14
+            0.4.26
             null
             null
-            0.5.14
-            0.5.14
-            null
-            0.4.25
-            0.4.25
-            0.4.25
+            0.4.26
             0.5.14
             null
-            0.4.25
-            0.5.14
-            0.5.14
             null
             0.5.14
             0.5.14
+            null
+            0.4.26
+            0.4.26
+            0.4.26
+            0.5.14
+            null
+            0.4.26
             0.5.14
             0.5.14
             null
@@ -146,7 +141,12 @@ class VersionResolverTest {
             0.5.14
             0.5.14
             0.5.14
-            0.4.25
+            null
+            0.5.14
+            0.5.14
+            0.5.14
+            0.5.14
+            0.4.26
             null
         """.trimIndent().split("\n")
 
@@ -154,8 +154,9 @@ class VersionResolverTest {
 
     @Test
     fun correctVersionsFromStringsAreObtained() {
+
         unsanitizedStrings.forEachIndexed(fun(index: Int, s: String) {
-            assertEquals(resolver.versionsFromString(s), correctVersionConstraints[index].split(", "))
+            assertEquals(correctVersionConstraints[index].split(", "), resolver.versionsFromString(s))
         })
     }
 


### PR DESCRIPTION
Regex-based approach is likely somewhat less reliable than tokenizing the string, but works without having to modify test cases much & removes dependency on better-parse which comes from a repo that enterprise users might not want to use.