### PR TITLE
Mitigate problems with internal services being down

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ gradle-app.setting
 *.asc
 *.project
 *.settings
+.idea

--- a/src/main/kotlin/org/web3j/sokt/VersionResolver.kt
+++ b/src/main/kotlin/org/web3j/sokt/VersionResolver.kt
@@ -53,10 +53,12 @@ class VersionResolver(private val directoryPath: String = ".web3j") {
             versionsFile.writeText(result)
             return Json(JsonConfiguration.Stable).parse(SolcRelease.serializer().list, result)
         } catch (e: Exception) {
-            if (versionsFile.exists()) {
-                return Json(JsonConfiguration.Stable).parse(SolcRelease.serializer().list, versionsFile.readText())
+            return if (versionsFile.exists()) {
+                Json(JsonConfiguration.Stable).parse(SolcRelease.serializer().list, versionsFile.readText())
+            } else {
+                var defaultReleases = ClassLoader.getSystemResource("releases.json").readText()
+                Json(JsonConfiguration.Stable).parse(SolcRelease.serializer().list, defaultReleases)
             }
-            throw Exception("Failed to get solidity version from server")
         }
     }
 

--- a/src/main/kotlin/org/web3j/sokt/VersionResolver.kt
+++ b/src/main/kotlin/org/web3j/sokt/VersionResolver.kt
@@ -48,7 +48,7 @@ class VersionResolver(private val directoryPath: String = ".web3j") {
     fun getSolcReleases(): List<SolcRelease> {
         val versionsFile = Paths.get(System.getProperty("user.home"), directoryPath, "solc", "releases.json").toFile()
         try {
-            val result = get("https://internal.services.web3labs.com/api/solidity/versions/")
+            val result = get("https://raw.githubusercontent.com/web3j/web3j-sokt/master/src/main/resources/releases.json")
             versionsFile.parentFile.mkdirs()
             versionsFile.writeText(result)
             return Json(JsonConfiguration.Stable).parse(SolcRelease.serializer().list, result)

--- a/src/main/kotlin/org/web3j/sokt/VersionResolver.kt
+++ b/src/main/kotlin/org/web3j/sokt/VersionResolver.kt
@@ -20,12 +20,15 @@ import java.io.BufferedReader
 import java.io.InputStreamReader
 import java.net.URL
 import java.nio.file.Paths
+import java.util.concurrent.TimeUnit
 import javax.net.ssl.HttpsURLConnection
 
 class VersionResolver(private val directoryPath: String = ".web3j") {
 
     operator fun get(uri: String): String {
         val con = URL(uri).openConnection() as HttpsURLConnection
+        con.connectTimeout = TimeUnit.MILLISECONDS.toMillis(200).toInt()
+        con.readTimeout = TimeUnit.SECONDS.toMillis(1).toInt()
         con.requestMethod = "GET"
         con.setRequestProperty("Content-Type", "application/json")
         con.setRequestProperty("Accept", "application/json")

--- a/src/main/resources/releases.json
+++ b/src/main/resources/releases.json
@@ -1,0 +1,356 @@
+[
+  {
+    "version": "0.4.16",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.4.16/solidity-windows.zip",
+    "mac_url": "",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.4.16/solc-static-linux"
+  },
+  {
+    "version": "0.4.17",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.4.17/solidity-windows.zip",
+    "mac_url": "",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.4.17/solc-static-linux"
+  },
+  {
+    "version": "0.4.18",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.4.18/solidity-windows.zip",
+    "mac_url": "",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.4.18/solc-static-linux"
+  },
+  {
+    "version": "0.4.19",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.4.19/solidity-windows.zip",
+    "mac_url": "",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.4.19/solc-static-linux"
+  },
+  {
+    "version": "0.4.20",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.4.20/solidity-windows.zip",
+    "mac_url": "",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.4.20/solc-static-linux"
+  },
+  {
+    "version": "0.4.21",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.4.21/solidity-windows.zip",
+    "mac_url": "",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.4.21/solc-static-linux"
+  },
+  {
+    "version": "0.4.22",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.4.22/solidity-windows.zip",
+    "mac_url": "",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.4.22/solc-static-linux"
+  },
+  {
+    "version": "0.4.23",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.4.23/solidity-windows.zip",
+    "mac_url": "",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.4.23/solc-static-linux"
+  },
+  {
+    "version": "0.4.24",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.4.24/solidity-windows.zip",
+    "mac_url": "",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.4.24/solc-static-linux"
+  },
+  {
+    "version": "0.4.25",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.4.25/solidity-windows.zip",
+    "mac_url": "https://github.com/web3j/solidity-darwin-binaries/releases/download/v0.4.25/solc_mac",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.4.25/solc-static-linux"
+  },
+  {
+    "version": "0.4.26",
+    "windows_url": "",
+    "mac_url": "",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.4.26/solc-static-linux"
+  },
+  {
+    "version": "0.5.0",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.5.0/solidity-windows.zip",
+    "mac_url": "https://github.com/web3j/solidity-darwin-binaries/releases/download/v0.5.0/solc_mac",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.5.0/solc-static-linux"
+  },
+  {
+    "version": "0.5.1",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.5.1/solidity-windows.zip",
+    "mac_url": "https://github.com/web3j/solidity-darwin-binaries/releases/download/v0.5.1/solc_mac",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.5.1/solc-static-linux"
+  },
+  {
+    "version": "0.5.2",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.5.2/solidity-windows.zip",
+    "mac_url": "https://github.com/web3j/solidity-darwin-binaries/releases/download/v0.5.2/solc_mac",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.5.2/solc-static-linux"
+  },
+  {
+    "version": "0.5.3",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.5.3/solidity-windows.zip",
+    "mac_url": "https://github.com/web3j/solidity-darwin-binaries/releases/download/v0.5.3/solc_mac",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.5.3/solc-static-linux"
+  },
+  {
+    "version": "0.5.4",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.5.4/solidity-windows.zip",
+    "mac_url": "https://github.com/web3j/solidity-darwin-binaries/releases/download/v0.5.4/solc_mac",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.5.4/solc-static-linux"
+  },
+  {
+    "version": "0.5.5",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.5.5/solidity-windows.zip",
+    "mac_url": "https://github.com/web3j/solidity-darwin-binaries/releases/download/v0.5.5/solc_mac",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.5.5/solc-static-linux"
+  },
+  {
+    "version": "0.5.6",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.5.6/solidity-windows.zip",
+    "mac_url": "https://github.com/web3j/solidity-darwin-binaries/releases/download/v0.5.6/solc_mac",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.5.6/solc-static-linux"
+  },
+  {
+    "version": "0.5.7",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.5.7/solidity-windows.zip",
+    "mac_url": "https://github.com/web3j/solidity-darwin-binaries/releases/download/v0.5.7/solc_mac",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.5.7/solc-static-linux"
+  },
+  {
+    "version": "0.5.8",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.5.8/solidity-windows.zip",
+    "mac_url": "https://github.com/web3j/solidity-darwin-binaries/releases/download/v0.5.8/solc_mac",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.5.8/solc-static-linux"
+  },
+  {
+    "version": "0.5.9",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.5.9/solidity-windows.zip",
+    "mac_url": "https://github.com/web3j/solidity-darwin-binaries/releases/download/v0.5.9/solc_mac",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.5.9/solc-static-linux"
+  },
+  {
+    "version": "0.5.10",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.5.10/solidity-windows.zip",
+    "mac_url": "https://github.com/web3j/solidity-darwin-binaries/releases/download/v0.5.10/solc_mac",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.5.10/solc-static-linux"
+  },
+  {
+    "version": "0.5.11",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.5.11/solidity-windows.zip",
+    "mac_url": "https://github.com/web3j/solidity-darwin-binaries/releases/download/v0.5.11/solc_mac",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.5.11/solc-static-linux"
+  },
+  {
+    "version": "0.5.12",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.5.12/solidity-windows.zip",
+    "mac_url": "https://github.com/web3j/solidity-darwin-binaries/releases/download/v0.5.12/solc_mac",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.5.12/solc-static-linux"
+  },
+  {
+    "version": "0.5.13",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.5.13/solidity-windows.zip",
+    "mac_url": "https://github.com/web3j/solidity-darwin-binaries/releases/download/v0.5.13/solc_mac",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.5.13/solc-static-linux"
+  },
+  {
+    "version": "0.5.14",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.5.14/solidity-windows.zip",
+    "mac_url": "https://github.com/web3j/solidity-darwin-binaries/releases/download/v0.5.14/solc_mac",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.5.14/solc-static-linux"
+  },
+  {
+    "version": "0.5.15",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.5.15/solidity-windows.zip",
+    "mac_url": "https://github.com/web3j/solidity-darwin-binaries/releases/download/v0.5.15/solc_mac",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.5.15/solc-static-linux"
+  },
+  {
+    "version": "0.5.16",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.5.16/solidity-windows.zip",
+    "mac_url": "https://github.com/web3j/solidity-darwin-binaries/releases/download/v0.5.16/solc_mac",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.5.16/solc-static-linux"
+  },
+  {
+    "version": "0.5.17",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.5.17/solidity-windows.zip",
+    "mac_url": "",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.5.17/solc-static-linux"
+  },
+  {
+    "version": "0.6.0",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.6.0/solidity-windows.zip",
+    "mac_url": "https://github.com/web3j/solidity-darwin-binaries/releases/download/v0.6.0/solc_mac",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.6.0/solc-static-linux"
+  },
+  {
+    "version": "0.6.1",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.6.1/solidity-windows.zip",
+    "mac_url": "https://github.com/web3j/solidity-darwin-binaries/releases/download/v0.6.1/solc_mac",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.6.1/solc-static-linux"
+  },
+  {
+    "version": "0.6.2",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.6.2/solidity-windows.zip",
+    "mac_url": "https://github.com/web3j/solidity-darwin-binaries/releases/download/v0.6.2/solc_mac",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.6.2/solc-static-linux"
+  },
+  {
+    "version": "0.6.3",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.6.3/solidity-windows.zip",
+    "mac_url": "",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.6.3/solc-static-linux"
+  },
+  {
+    "version": "0.6.4",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.6.4/solidity-windows.zip",
+    "mac_url": "",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.6.4/solc-static-linux"
+  },
+  {
+    "version": "0.6.5",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.6.5/solidity-windows.zip",
+    "mac_url": "",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.6.5/solc-static-linux"
+  },
+  {
+    "version": "0.6.6",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.6.6/solidity-windows.zip",
+    "mac_url": "",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.6.6/solc-static-linux"
+  },
+  {
+    "version": "0.6.7",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.6.7/solidity-windows.zip",
+    "mac_url": "",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.6.7/solc-static-linux"
+  },
+  {
+    "version": "0.6.8",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.6.8/solidity-windows.zip",
+    "mac_url": "",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.6.8/solc-static-linux"
+  },
+  {
+    "version": "0.6.9",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.6.9/solidity-windows.zip",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.6.9/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.6.9/solc-static-linux"
+  },
+  {
+    "version": "0.6.10",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.6.10/solidity-windows.zip",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.6.10/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.6.10/solc-static-linux"
+  },
+  {
+    "version": "0.6.11",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.6.11/solidity-windows.zip",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.6.11/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.6.11/solc-static-linux"
+  },
+  {
+    "version": "0.6.12",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.6.12/solidity-windows.zip",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.6.12/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.6.12/solc-static-linux"
+  },
+  {
+    "version": "0.7.0",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.7.0/solidity-windows.zip",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.7.0/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.7.0/solc-static-linux"
+  },
+  {
+    "version": "0.7.1",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.7.1/solidity-windows.zip",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.7.1/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.7.1/solc-static-linux"
+  },
+  {
+    "version": "0.7.2",
+    "windows_url": "",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.7.2/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.7.2/solc-static-linux"
+  },
+  {
+    "version": "0.7.3",
+    "windows_url": "",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.7.3/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.7.3/solc-static-linux"
+  },
+  {
+    "version": "0.7.4",
+    "windows_url": "",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.7.4/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.7.4/solc-static-linux"
+  },
+  {
+    "version": "0.7.5",
+    "windows_url": "",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.7.5/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.7.5/solc-static-linux"
+  },
+  {
+    "version": "0.7.6",
+    "windows_url": "",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.7.6/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.7.6/solc-static-linux"
+  },
+  {
+    "version": "0.8.0",
+    "windows_url": "",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.8.0/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.8.0/solc-static-linux"
+  },
+  {
+    "version": "0.8.1",
+    "windows_url": "",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.8.1/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.8.1/solc-static-linux"
+  },
+  {
+    "version": "0.8.2",
+    "windows_url": "",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.8.2/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.8.2/solc-static-linux"
+  },
+  {
+    "version": "0.8.3",
+    "windows_url": "",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.8.3/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.8.3/solc-static-linux"
+  },
+  {
+    "version": "0.8.4",
+    "windows_url": "",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.8.4/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.8.4/solc-static-linux"
+  },
+  {
+    "version": "0.8.5",
+    "windows_url": "",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.8.5/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.8.5/solc-static-linux"
+  },
+  {
+    "version": "0.8.6",
+    "windows_url": "",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.8.6/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.8.6/solc-static-linux"
+  },
+  {
+    "version": "0.8.7",
+    "windows_url": "",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.8.7/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.8.7/solc-static-linux"
+  },
+  {
+    "version": "0.8.8",
+    "windows_url": "",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.8.8/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.8.8/solc-static-linux"
+  },
+  {
+    "version": "0.8.9",
+    "windows_url": "",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.8.9/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.8.9/solc-static-linux"
+  }
+]


### PR DESCRIPTION
Fetch `releases.json` direct from github

Fallback quickly to local file in jar


Fixes: https://github.com/web3j/web3j-sokt/issues/7

Potentially allows https://github.com/web3j/web3j-sokt/issues/6 

Allows https://github.com/web3j/web3j-sokt/issues/5