### PR TITLE
392 update solc release versions

### DIFF
--- a/src/main/resources/releases.json
+++ b/src/main/resources/releases.json
@@ -352,5 +352,23 @@
     "windows_url": "",
     "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.8.9/solc-macos",
     "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.8.9/solc-static-linux"
+  },
+  {
+    "version": "0.8.10",
+    "windows_url": "",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.8.10/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.8.10/solc-static-linux"
+  },
+  {
+    "version": "0.8.11",
+    "windows_url": "",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.8.11/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.8.11/solc-static-linux"
+  },
+  {
+    "version": "0.8.12",
+    "windows_url": "",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.8.12/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.8.12/solc-static-linux"
   }
 ]


### PR DESCRIPTION
### What does this PR do?
Added supporting of new solc versions 0.8.10 / 0.8.11 / 0.8.12

### Why is it needed?
To compile solidity contracts with latest versions (0.8.10 / 0.8.11 / 0.8.12) Mac / Linux
