### PR TITLE
Adds solidity version 0.8.13 to releases.json

### DIFF
--- a/src/main/resources/releases.json
+++ b/src/main/resources/releases.json
@@ -370,5 +370,11 @@
     "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.8.12/solc-windows.exe",
     "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.8.12/solc-macos",
     "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.8.12/solc-static-linux"
+  },
+  {
+    "version": "0.8.13",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.8.13/solc-windows.exe",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.8.13/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.8.13/solc-static-linux"
   }
 ]


### PR DESCRIPTION
While waiting for https://github.com/web3j/web3j-sokt/issues/13 to be picked up, this PR adds the latest solidity version to unblock others who are not able to use the library.