### PR TITLE
Adds solidity versions up to 0.8.17 to releases.json

### DIFF
--- a/src/main/resources/releases.json
+++ b/src/main/resources/releases.json
@@ -376,5 +376,29 @@
     "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.8.13/solc-windows.exe",
     "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.8.13/solc-macos",
     "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.8.13/solc-static-linux"
+  },
+  {
+    "version": "0.8.14",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.8.14/solc-windows.exe",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.8.14/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.8.14/solc-static-linux"
+  },
+  {
+    "version": "0.8.15",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.8.15/solc-windows.exe",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.8.15/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.8.15/solc-static-linux"
+  },
+  {
+    "version": "0.8.16",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.8.16/solc-windows.exe",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.8.16/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.8.16/solc-static-linux"
+  },
+  {
+    "version": "0.8.17",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.8.17/solc-windows.exe",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.8.17/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.8.17/solc-static-linux"
   }
 ]


### PR DESCRIPTION
### What does this PR do?
Updates the `releases.json` file with newer versions of solidity compiler

### Where should the reviewer start?
Added versions are `0.8.14` through `0.8.17`.

### Why is it needed?
To be able to generate Java bindings for contracts declaring pragma with newer solc version to be used.

