### PR TITLE
Add release information for version 0.8.30

### DIFF
--- a/src/main/resources/releases.json
+++ b/src/main/resources/releases.json
@@ -472,5 +472,11 @@
     "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.8.29/solc-windows.exe",
     "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.8.29/solc-macos",
     "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.8.29/solc-static-linux"
+  },
+    {
+    "version": "0.8.30",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.8.30/solc-windows.exe",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.8.30/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.8.30/solc-static-linux"
   }
 ]

--- a/src/main/resources/releases.json
+++ b/src/main/resources/releases.json
@@ -473,7 +473,7 @@
     "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.8.29/solc-macos",
     "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.8.29/solc-static-linux"
   },
-    {
+  {
     "version": "0.8.30",
     "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.8.30/solc-windows.exe",
     "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.8.30/solc-macos",


### PR DESCRIPTION
### What does this PR do?
Add release information for version 0.8.30

### Where should the reviewer start?
src/main/resources/releases.json:475

### Why is it needed?
Some developers would love to use solc v0.8.30. 😈

## Checklist

- [ ] I've read the contribution guidelines.
- [ ] I've added tests (if applicable).
- [ ] I've added a changelog entry if necessary.