### PR TITLE
Fetch solc binaries dynamically from official Solidity sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* NIL
+* Replace static compiler release lookup with official Solidity binary index resolution [#13](https://github.com/LFDT-web3j/web3j-sokt/pull/13)
+* Add dynamic platform-specific `solc` binary discovery and Linux ARM64 support [#40](https://github.com/LFDT-web3j/web3j-sokt/issues/40)
 
 ### BREAKING CHANGES
 

--- a/src/main/kotlin/org/web3j/sokt/SolcInstance.kt
+++ b/src/main/kotlin/org/web3j/sokt/SolcInstance.kt
@@ -40,18 +40,22 @@ class SolcInstance(
 
     fun install(): Boolean {
         println("Solidity version ${solcRelease.version} is not installed. Downloading and installing it to ~/$directoryPath/solc/${solcRelease.version}")
+        val downloadUrl = solcRelease.downloadUrl()
+        if (downloadUrl.isBlank()) {
+            return false
+        }
         when {
             SystemUtils.IS_OS_WINDOWS -> {
                 solcFile.parentFile.mkdirs()
 
-                if (solcRelease.version.compareTo("0.7.1") > 0) {
-                    solcFile.writeBytes(URL(solcRelease.windowsUrl).readBytes())
+                if (!solcRelease.isWindowsArchive()) {
+                    solcFile.writeBytes(URL(downloadUrl).readBytes())
                     if (installed()) {
                         solcFile.setExecutable(true)
                     }
                 } else {
                     val winDownloadFile = File("${solcFile.absolutePath.dropLast(4)}.zip")
-                    winDownloadFile.writeBytes(URL(solcRelease.windowsUrl).readBytes())
+                    winDownloadFile.writeBytes(URL(downloadUrl).readBytes())
                     ZipFile(winDownloadFile).use { zip ->
                         zip.entries().asSequence().forEach { entry ->
                             zip.getInputStream(entry).use { input ->
@@ -64,11 +68,10 @@ class SolcInstance(
                     }
                     winDownloadFile.delete()
                 }
-                return true
+                return installed()
             }
             SystemUtils.IS_OS_LINUX || SystemUtils.IS_OS_MAC -> {
                 solcFile.parentFile.mkdirs()
-                val downloadUrl = if (SystemUtils.IS_OS_MAC) solcRelease.macUrl else solcRelease.linuxUrl
                 solcFile.writeBytes(URL(downloadUrl).readBytes())
                 if (installed()) {
                     solcFile.setExecutable(true)

--- a/src/main/kotlin/org/web3j/sokt/SolcRelease.kt
+++ b/src/main/kotlin/org/web3j/sokt/SolcRelease.kt
@@ -23,7 +23,20 @@ data class SolcRelease(
     @SerialName("linux_url") val linuxUrl: String = "",
     @SerialName("mac_url") val macUrl: String = "",
 ) {
+    fun downloadUrl(): String {
+        return when {
+            SystemUtils.IS_OS_WINDOWS -> windowsUrl
+            SystemUtils.IS_OS_LINUX -> linuxUrl
+            SystemUtils.IS_OS_MAC -> macUrl
+            else -> ""
+        }
+    }
+
+    fun isWindowsArchive(): Boolean {
+        return SystemUtils.IS_OS_WINDOWS && downloadUrl().lowercase().endsWith(".zip")
+    }
+
     fun isCompatibleWithOs(): Boolean {
-        return windowsUrl.isNotBlank() && SystemUtils.IS_OS_WINDOWS || linuxUrl.isNotBlank() && SystemUtils.IS_OS_LINUX || macUrl.isNotBlank() && SystemUtils.IS_OS_MAC
+        return downloadUrl().isNotBlank()
     }
 }

--- a/src/main/kotlin/org/web3j/sokt/VersionResolver.kt
+++ b/src/main/kotlin/org/web3j/sokt/VersionResolver.kt
@@ -14,7 +14,9 @@ package org.web3j.sokt
 
 import com.github.zafarkhaja.semver.Version
 import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import org.apache.commons.lang3.SystemUtils
 import java.io.BufferedReader
 import java.io.InputStreamReader
 import java.net.URL
@@ -22,7 +24,46 @@ import java.nio.file.Paths
 import java.util.concurrent.TimeUnit
 import javax.net.ssl.HttpsURLConnection
 
+internal enum class SolcPlatform(val directoryName: String) {
+    WINDOWS_AMD64("windows-amd64"),
+    LINUX_AMD64("linux-amd64"),
+    LINUX_ARM64("linux-arm64"),
+    MACOSX_AMD64("macosx-amd64"),
+    ;
+
+    val indexUrl: String = "https://binaries.soliditylang.org/$directoryName/list.json"
+
+    fun binaryUrl(path: String): String = "https://binaries.soliditylang.org/$directoryName/$path"
+
+    companion object {
+        fun current(): SolcPlatform? {
+            val architecture = System.getProperty("os.arch").lowercase()
+            return when {
+                SystemUtils.IS_OS_WINDOWS -> WINDOWS_AMD64
+                SystemUtils.IS_OS_MAC -> MACOSX_AMD64
+                SystemUtils.IS_OS_LINUX && architecture in setOf("aarch64", "arm64") -> LINUX_ARM64
+                SystemUtils.IS_OS_LINUX -> LINUX_AMD64
+                else -> null
+            }
+        }
+    }
+}
+
+@Serializable
+private data class SolcBuildIndex(
+    val builds: List<SolcBuild>,
+    val releases: Map<String, String> = emptyMap(),
+)
+
+@Serializable
+private data class SolcBuild(
+    val path: String,
+    val version: String,
+    val prerelease: String? = null,
+)
+
 class VersionResolver(private val directoryPath: String = ".web3j") {
+    private val json = Json { ignoreUnknownKeys = true }
 
     operator fun get(uri: String): String {
         val con = URL(uri).openConnection() as HttpsURLConnection
@@ -45,18 +86,20 @@ class VersionResolver(private val directoryPath: String = ".web3j") {
     }
 
     fun getSolcReleases(): List<SolcRelease> {
-        val versionsFile = Paths.get(System.getProperty("user.home"), directoryPath, "solc", "releases.json").toFile()
-        try {
-            val result = get("https://raw.githubusercontent.com/LFDT-web3j/web3j-sokt/main/src/main/resources/releases.json")
+        val platform = SolcPlatform.current() ?: return bundledSolcReleases()
+        val versionsFile = Paths.get(System.getProperty("user.home"), directoryPath, "solc", "${platform.directoryName}-list.json").toFile()
+        return runCatching {
+            val result = get(platform.indexUrl)
             versionsFile.parentFile.mkdirs()
             versionsFile.writeText(result)
-            return Json.decodeFromString<List<SolcRelease>>(result)
-        } catch (e: Exception) {
-            return if (versionsFile.exists()) {
-                Json.decodeFromString<List<SolcRelease>>(versionsFile.readText())
+            solcReleasesFromOfficialIndex(result, platform)
+        }.getOrElse {
+            if (versionsFile.exists()) {
+                runCatching { solcReleasesFromOfficialIndex(versionsFile.readText(), platform) }.getOrElse {
+                    bundledSolcReleases()
+                }
             } else {
-                val defaultReleases = ClassLoader.getSystemResource("releases.json").readText()
-                Json.decodeFromString<List<SolcRelease>>(defaultReleases)
+                bundledSolcReleases()
             }
         }
     }
@@ -81,7 +124,32 @@ class VersionResolver(private val directoryPath: String = ".web3j") {
         return if (pragmaRequirement != null) {
             getCompatibleVersions(pragmaRequirement, solcReleases).lastOrNull()
         } else {
-            solcReleases.last()
+            solcReleases.lastOrNull { it.isCompatibleWithOs() }
+        }
+    }
+
+    internal fun solcReleasesFromOfficialIndex(input: String, platform: SolcPlatform): List<SolcRelease> {
+        val buildIndex = json.decodeFromString<SolcBuildIndex>(input)
+        val stableReleases = if (buildIndex.releases.isNotEmpty()) {
+            buildIndex.releases.entries.map { (version, path) -> platform.toSolcRelease(version, path) }
+        } else {
+            buildIndex.builds.filter { it.prerelease == null }.map { platform.toSolcRelease(it.version, it.path) }
+        }
+
+        return stableReleases.sortedBy { Version.valueOf(it.version) }
+    }
+
+    private fun bundledSolcReleases(): List<SolcRelease> {
+        val defaultReleases = ClassLoader.getSystemResource("releases.json").readText()
+        return json.decodeFromString<List<SolcRelease>>(defaultReleases)
+    }
+
+    private fun SolcPlatform.toSolcRelease(version: String, path: String): SolcRelease {
+        val binaryUrl = binaryUrl(path)
+        return when (this) {
+            SolcPlatform.WINDOWS_AMD64 -> SolcRelease(version = version, windowsUrl = binaryUrl)
+            SolcPlatform.LINUX_AMD64, SolcPlatform.LINUX_ARM64 -> SolcRelease(version = version, linuxUrl = binaryUrl)
+            SolcPlatform.MACOSX_AMD64 -> SolcRelease(version = version, macUrl = binaryUrl)
         }
     }
 }

--- a/src/test/kotlin/org/web3j/sokt/VersionResolverTest.kt
+++ b/src/test/kotlin/org/web3j/sokt/VersionResolverTest.kt
@@ -12,7 +12,6 @@
  */
 package org.web3j.sokt
 
-import com.github.zafarkhaja.semver.Version
 import org.apache.commons.lang3.SystemUtils
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -106,94 +105,6 @@ class VersionResolverTest {
             ~0.4.24, >=0.5
         """.trimIndent().split("\n")
 
-    private val correctWindowsVersions =
-        """
-            0.5.13
-            0.5.14
-            0.4.25
-            0.5.14
-            0.5.14
-            0.5.14
-            0.5.14
-            0.4.25
-            0.4.25
-            null
-            0.4.25
-            null
-            null
-            0.4.25
-            0.5.14
-            null
-            null
-            0.5.14
-            0.5.14
-            null
-            0.4.25
-            0.4.25
-            0.4.25
-            0.5.14
-            null
-            0.4.25
-            0.5.14
-            0.5.14
-            null
-            0.5.14
-            0.5.14
-            0.5.14
-            0.5.14
-            null
-            0.5.14
-            0.5.14
-            0.5.14
-            0.5.14
-            0.4.25
-            null
-        """.trimIndent().split("\n")
-
-    private val correctLinuxVersions =
-        """
-            0.5.13
-            0.5.14
-            0.4.26
-            0.5.14
-            0.5.14
-            0.5.14
-            0.5.14
-            0.4.26
-            0.4.26
-            null
-            0.4.26
-            null
-            null
-            0.4.26
-            0.5.14
-            null
-            null
-            0.5.14
-            0.5.14
-            null
-            0.4.26
-            0.4.26
-            0.4.26
-            0.5.14
-            null
-            0.4.26
-            0.5.14
-            0.5.14
-            null
-            0.5.14
-            0.5.14
-            0.5.14
-            0.5.14
-            null
-            0.5.14
-            0.5.14
-            0.5.14
-            0.5.14
-            0.4.26
-            null
-        """.trimIndent().split("\n")
-
     private val resolver = VersionResolver()
 
     @Test
@@ -204,26 +115,69 @@ class VersionResolverTest {
     }
 
     @Test
-    fun correctSolidityVersionFromConstraintsIsResolved() {
-        // Filter is needed as test was written at 0.5.14 and new releases since this version will cause resolved version to be different from expected
-        val releases = resolver.getSolcReleases().filter { Version.valueOf(it.version).lessThan(Version.valueOf("0.5.15")) }
-        // Mac will not be able to do this as we don't have solc builds for every solc version tested here
-        if (SystemUtils.IS_OS_WINDOWS) {
-            verifyVersions(correctWindowsVersions, releases)
-        } else if (SystemUtils.IS_OS_LINUX) {
-            verifyVersions(correctLinuxVersions, releases)
-        }
+    fun officialSolcIndexIsConvertedToStableReleases() {
+        val releases = resolver.solcReleasesFromOfficialIndex(
+            """
+            {
+              "builds": [
+                {
+                  "path": "solc-linux-amd64-v0.8.35-pre.1+commit.a99b6d8c",
+                  "version": "0.8.35",
+                  "prerelease": "pre.1"
+                },
+                {
+                  "path": "solc-linux-amd64-v0.8.34+commit.80d5c536",
+                  "version": "0.8.34"
+                },
+                {
+                  "path": "solc-linux-amd64-v0.8.35+commit.47b9dedd",
+                  "version": "0.8.35"
+                }
+              ],
+              "releases": {
+                "0.8.35": "solc-linux-amd64-v0.8.35+commit.47b9dedd",
+                "0.8.34": "solc-linux-amd64-v0.8.34+commit.80d5c536"
+              },
+              "latestRelease": "0.8.35"
+            }
+            """.trimIndent(),
+            SolcPlatform.LINUX_AMD64,
+        )
+
+        assertEquals(listOf("0.8.34", "0.8.35"), releases.map { it.version })
+        assertEquals(
+            "https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.35+commit.47b9dedd",
+            releases.last().linuxUrl,
+        )
     }
 
-    private fun verifyVersions(versions: List<String>, releases: List<SolcRelease>) {
-        unsanitizedStrings.forEachIndexed(fun(index: Int, s: String) {
-            val correctVersion = versions[index]
-            val resolvedVersion = resolver.getCompatibleVersions(s, releases).lastOrNull()
-            if (resolvedVersion == null) {
-                assertEquals(correctVersion, "null")
-            } else {
-                assertEquals(correctVersion, resolvedVersion.version)
-            }
-        })
+    @Test
+    fun compatibleVersionsAreResolvedFromStableReleaseSet() {
+        val releases =
+            listOf("0.4.0", "0.4.2", "0.4.21", "0.4.23", "0.4.25", "0.4.26", "0.5.0", "0.5.13", "0.5.14")
+                .map(::releaseForCurrentOs)
+
+        verifyVersion(">=0.5.10<0.5.14;", "0.5.13", releases)
+        verifyVersion("^0.4.2;", "0.4.26", releases)
+        verifyVersion(">0.4.23 <0.5.0;", "0.4.26", releases)
+        verifyVersion("0.4.2;", "0.4.2", releases)
+        verifyVersion("0.4.0;", "0.4.0", releases)
+        verifyVersion(">=0.4.0 <0.4.8;", "0.4.2", releases)
+        verifyVersion("~0.4.24;", "0.4.26", releases)
+        verifyVersion("~0.4.24 >=0.5;", null, releases)
+    }
+
+    private fun verifyVersion(pragma: String, expectedVersion: String?, releases: List<SolcRelease>) {
+        assertEquals(expectedVersion, resolver.getCompatibleVersions(pragma, releases).lastOrNull()?.version)
+    }
+
+    private fun releaseForCurrentOs(version: String): SolcRelease {
+        val url = "https://example.invalid/$version/solc"
+        return when {
+            SystemUtils.IS_OS_WINDOWS -> SolcRelease(version = version, windowsUrl = "$url.exe")
+            SystemUtils.IS_OS_LINUX -> SolcRelease(version = version, linuxUrl = url)
+            SystemUtils.IS_OS_MAC -> SolcRelease(version = version, macUrl = url)
+            else -> SolcRelease(version = version)
+        }
     }
 }


### PR DESCRIPTION
Fixes #13, #12, #40

  ### What does this PR do?
  This PR replaces Sokt's project-owned `releases.json` fetch path with Solidity's official platform-specific binary
  indexes from `binaries.soliditylang.org`.

  It:
  - resolves `solc` versions from the upstream `list.json` for the current platform
  - caches the upstream index under `~/.web3j/solc/`
  - derives download URLs dynamically instead of requiring a new Sokt release for each new Solidity release
  - preserves fallback behavior to the bundled `releases.json` if the upstream fetch or cache read fails
  - updates Windows install handling to detect `.zip` vs `.exe` from the resolved URL instead of using a hardcoded
  version cutoff
  - adds tests for official index parsing and stable version resolution

  ### Where should the reviewer start?
  Start with `src/main/kotlin/org/web3j/sokt/VersionResolver.kt`, since that contains the core change from the
  static release catalog to the official upstream index flow.

  Then review:
  - `src/main/kotlin/org/web3j/sokt/SolcInstance.kt`
  - `src/main/kotlin/org/web3j/sokt/SolcRelease.kt`
  - `src/test/kotlin/org/web3j/sokt/VersionResolverTest.kt`

  ### Why is it needed?
  Today Sokt depends on a repo-maintained `releases.json`, which means new `solc` releases require publishing a new
  Sokt release before users can resolve and install them.

  Using Solidity's official binary indexes removes that maintenance bottleneck, keeps Sokt aligned with upstream
  releases automatically, and avoids users getting blocked when contracts target newer Solidity versions.

  ## Checklist

  - [x] I've read the contribution guidelines.
  - [x] I've added tests (if applicable).
  - [x] I've added a changelog entry if necessary.
