### PR TITLE
fix: Ensure bundled releases.json is always found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,12 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-* NIL
+* Load the bundled `releases.json` fallback via the class's own classloader so the offline fallback works under isolated classloaders (Gradle plugins, OSGi) [#45](https://github.com/LFDT-web3j/web3j-sokt/pull/45)
 
 ### Features
 
 * Replace static compiler release lookup with official Solidity binary index resolution [#13](https://github.com/LFDT-web3j/web3j-sokt/pull/13)
+* Bundle Solidity releases 0.8.31–0.8.35 (with linux-arm64 URLs) in the offline fallback [#45](https://github.com/LFDT-web3j/web3j-sokt/pull/45)
 
 ### BREAKING CHANGES
 

--- a/src/main/kotlin/org/web3j/sokt/VersionResolver.kt
+++ b/src/main/kotlin/org/web3j/sokt/VersionResolver.kt
@@ -13,8 +13,8 @@
 package org.web3j.sokt
 
 import com.github.zafarkhaja.semver.Version
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import org.apache.commons.lang3.SystemUtils
 import java.io.BufferedReader
@@ -140,7 +140,11 @@ class VersionResolver(private val directoryPath: String = ".web3j") {
     }
 
     private fun bundledSolcReleases(): List<SolcRelease> {
-        val defaultReleases = ClassLoader.getSystemResource("releases.json").readText()
+        val bundled = VersionResolver::class.java.getResourceAsStream("/releases.json")
+            ?: throw IllegalStateException(
+                "Unable to load the bundled releases.json fallback from the classpath",
+            )
+        val defaultReleases = bundled.bufferedReader().use { it.readText() }
         return json.decodeFromString<List<SolcRelease>>(defaultReleases)
     }
 

--- a/src/main/resources/releases.json
+++ b/src/main/resources/releases.json
@@ -478,5 +478,40 @@
     "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.8.30/solc-windows.exe",
     "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.8.30/solc-macos",
     "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.8.30/solc-static-linux"
+  },
+  {
+    "version": "0.8.31",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.8.31/solc-windows.exe",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.8.31/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.8.31/solc-static-linux",
+    "linux_arm64_url": "https://github.com/ethereum/solidity/releases/download/v0.8.31/solc-static-linux-arm"
+  },
+  {
+    "version": "0.8.32",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.8.32/solc-windows.exe",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.8.32/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.8.32/solc-static-linux",
+    "linux_arm64_url": "https://github.com/ethereum/solidity/releases/download/v0.8.32/solc-static-linux-arm"
+  },
+  {
+    "version": "0.8.33",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.8.33/solc-windows.exe",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.8.33/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.8.33/solc-static-linux",
+    "linux_arm64_url": "https://github.com/ethereum/solidity/releases/download/v0.8.33/solc-static-linux-arm"
+  },
+  {
+    "version": "0.8.34",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.8.34/solc-windows.exe",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.8.34/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.8.34/solc-static-linux",
+    "linux_arm64_url": "https://github.com/ethereum/solidity/releases/download/v0.8.34/solc-static-linux-arm"
+  },
+  {
+    "version": "0.8.35",
+    "windows_url": "https://github.com/ethereum/solidity/releases/download/v0.8.35/solc-windows.exe",
+    "mac_url": "https://github.com/ethereum/solidity/releases/download/v0.8.35/solc-macos",
+    "linux_url": "https://github.com/ethereum/solidity/releases/download/v0.8.35/solc-static-linux",
+    "linux_arm64_url": "https://github.com/ethereum/solidity/releases/download/v0.8.35/solc-static-linux-arm"
   }
 ]

--- a/src/test/kotlin/org/web3j/sokt/VersionResolverTest.kt
+++ b/src/test/kotlin/org/web3j/sokt/VersionResolverTest.kt
@@ -12,8 +12,11 @@
  */
 package org.web3j.sokt
 
+import kotlinx.serialization.json.Json
 import org.apache.commons.lang3.SystemUtils
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class VersionResolverTest {
@@ -165,6 +168,18 @@ class VersionResolverTest {
         verifyVersion(">=0.4.0 <0.4.8;", "0.4.2", releases)
         verifyVersion("~0.4.24;", "0.4.26", releases)
         verifyVersion("~0.4.24 >=0.5;", null, releases)
+    }
+
+    @Test
+    fun bundledReleasesFallbackIsReachableViaTheClassClassloader() {
+        val stream = VersionResolver::class.java.getResourceAsStream("/releases.json")
+        assertNotNull(stream, "releases.json must be loadable via the sokt class loader")
+
+        val releases = Json { ignoreUnknownKeys = true }.decodeFromString<List<SolcRelease>>(
+            stream!!.bufferedReader().use { it.readText() },
+        )
+        assertTrue(releases.isNotEmpty())
+        assertTrue(releases.all { it.version.isNotBlank() })
     }
 
     private fun verifyVersion(pragma: String, expectedVersion: String?, releases: List<SolcRelease>) {


### PR DESCRIPTION
### What does this PR do?

Two related changes to the offline `releases.json` fallback:                                                                                                                                                                      
                                                                                                                                                                                                                                    
  1. **Fixes the fallback under isolated classloaders.** `VersionResolver.getSolcReleases()` falls back to a bundled `releases.json` when the Solidity binary index can't be fetched from the network. That fallback loaded the     
  resource via `ClassLoader.getSystemResource("releases.json")`, which resolves against the **system/application** classloader. Under an isolated classloader — Gradle plugins, OSGi, app servers — sokt is not on the system       
  classpath, so the lookup returns `null` and the fallback throws a `NullPointerException` instead of recovering. This PR loads it via the class's own classloader:                                                                 
                                                                                                                                                                                                                                    
     ```kotlin                                                                                                                                                                                                                      
     val bundled = VersionResolver::class.java.getResourceAsStream("/releases.json")                                                                                                                                                
         ?: throw IllegalStateException(                                                                                                                                                                                            
             "Unable to load the bundled releases.json fallback from the classpath",                                                                                                                                                
         )                                                                                                                                                                                                                          
     ```                                                                                                                                                                                                                            
                                                                                                                                                                                                                                    
     `VersionResolver::class.java.getResourceAsStream(...)` resolves against the classloader that loaded sokt, so it works whether sokt is on the system classpath (CLI) or a child/isolated classloader (Gradle plugin). It also   
  replaces the silent NPE with a clear `IllegalStateException`.                                                                                                                                                                     
                                                                                                                                                                                                                                    
  2. **Refreshes the bundled release list.** Adds Solidity 0.8.31–0.8.35 to `releases.json`. These are the first releases to ship a `solc-static-linux-arm` asset, so each new entry includes `linux_arm64_url`; earlier releases   
  have no arm64 binary on GitHub and correctly omit it. All 20 new asset URLs were verified to resolve (HTTP 200).                                                                                                                  
                                                                                                                                                                                                                                    
  ### Where should the reviewer start?                                                                                                                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                    
  - `src/main/kotlin/org/web3j/sokt/VersionResolver.kt` — the `bundledSolcReleases()` helper (the classloader fix).                                                                                                                 
  - `src/main/resources/releases.json` — the six-version diff at the end of the array.                                                                                                                                              
  - `src/test/kotlin/org/web3j/sokt/VersionResolverTest.kt` — `bundledReleasesFallbackIsReachableViaTheClassClassloader` guards that `/releases.json` is loadable via the sokt class loader and parses into a non-empty release     
  list.                                                                                                                                                                                                                             
                                                                                                                                                                                                                                    
  ### Why is it needed?                                                                                                                                                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                    
  The offline fallback is meant to save builds when the network is unavailable, but under a Gradle plugin classloader it was the very thing that threw. This is what makes `web3j-solidity-gradle-plugin` fail offline with "Failed 
  to get solidity version from server". Fixes LFDT-web3j/web3j-solidity-gradle-plugin#48 and Fixes LFDT-web3j/web3j-solidity-gradle-plugin#53. Bundling the latest releases also keeps the offline fallback current with upstream Solidity.                                                                                                                                       
                                                                                                                                                                                                                                    
  ## Checklist                                                                                                                                                                                                                      
                                                                                                                                                                                                                                    
  - [x] I've read the contribution guidelines.                                                                                                                                                                                      
  - [x] I've added tests (if applicable).                                                                                                                                                                                           
  - [X] I've added a changelog entry if necessary. 