### PR TITLE
Fix using releases.json version 0.6.0

### DIFF
--- a/src/main/kotlin/org/web3j/sokt/VersionResolver.kt
+++ b/src/main/kotlin/org/web3j/sokt/VersionResolver.kt
@@ -47,7 +47,7 @@ class VersionResolver(private val directoryPath: String = ".web3j") {
     fun getSolcReleases(): List<SolcRelease> {
         val versionsFile = Paths.get(System.getProperty("user.home"), directoryPath, "solc", "releases.json").toFile()
         try {
-            val result = get("https://raw.githubusercontent.com/LFDT-web3j/web3j-sokt/main/src/main/resources/releases.json")
+            val result = get("https://raw.githubusercontent.com/LFDT-web3j/web3j-sokt/refs/heads/release/0.6.0/src/main/resources/releases.json")
             versionsFile.parentFile.mkdirs()
             versionsFile.writeText(result)
             return Json.decodeFromString<List<SolcRelease>>(result)


### PR DESCRIPTION
### What does this PR do?
Fixed the problem "Unexpected JSON token at offset 25026: Encountered an unknown key linux_arm64_url"
for release version 0.6.0

Linked web3j-maven-plugin issue: https://github.com/LFDT-web3j/web3j-maven-plugin/issues/146

### Where should the reviewer start?

https://github.com/LFDT-web3j/web3j-maven-plugin/issues/146

### Why is it needed?
Recent updates to `releases.json` on the `main` branch have caused errors in the `web3j-maven-plugin`.

## Checklist

- [x] I've read the contribution guidelines.
- [ ] I've added tests (if applicable).
- [ ] I've added a changelog entry if necessary.