### PR TITLE
fix: replace legacy oss.sonatype.org repos with central.sonatype.com snapshot repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-* NIL
+* Remove legacy unstable oss.sonatype.org repositories to prevent 504 gateway timeouts during dependency resolution
 
 ### Features
 

--- a/gradle/repositories/build.gradle
+++ b/gradle/repositories/build.gradle
@@ -1,6 +1,4 @@
 repositories {
     mavenCentral()
-    jcenter()
-    maven { url 'https://oss.sonatype.org/content/repositories/releases/' }
-    maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
+    maven { url 'https://central.sonatype.com/repository/maven-snapshots/' }
 }


### PR DESCRIPTION
Removes legacy jcenter and oss.sonatype.org repository entries and replaces them with central.sonatype.com snapshot repository.
